### PR TITLE
Add Github Action to publish on each new release

### DIFF
--- a/.github/workflows/publish_on_release.yml
+++ b/.github/workflows/publish_on_release.yml
@@ -1,0 +1,18 @@
+name: publish node package to npm
+on:
+  release:
+    types: [created]
+jobs:
+  publish_to_npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
If you create an [Access Token on npm](https://docs.npmjs.com/creating-and-viewing-access-tokens) (I suggest Automation type if you use 2FA as you should) and add it to the Secrets sections of the repository Settings page, you can create a new release from Github and a new version will automatically be publish to npm. Use `NPM_TOKEN` as secret name, or you'd need to change the last line of `publish-on-release.yml` file.

Full guide here: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages


<img width="1124" alt="Screenshot 2021-12-29 at 17 27 49" src="https://user-images.githubusercontent.com/898057/147683259-f63f5b75-90f6-4303-a1cc-95b479978fad.png">
 