### PR TITLE
Update ssh2-sftp-client dependecy

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "license": "ISC",
   "dependencies": {
     "ftp": "^0.3.10",
-    "ssh2-sftp-client": "^4.1.0"
+    "ssh2-sftp-client": "^9.0.4"
   }
 }


### PR DESCRIPTION
Which in turn uses the latest ssh2 release, with important secuity fixes.

In my testing everything works fine, but since it's a breaking change in the dependency, it should probably bump the MAJOR here too.